### PR TITLE
Show defaults on CLI help message

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,13 +57,15 @@ Usage: stas-ln-translator [OPTIONS] INPUT OUTPUT
 
 Options:
   -v, --version              Show the version and exit.
-  --batch_size INTEGER       Number of lines per batch in a request. Only
-                             works when request_type is 'Batch'.
+  --batch_size INTEGER       Number of lines per batch in a request. Batch
+                             request type only.  [default: 100]
   --request_type TEXT        Request type used when contacting API. Either
-                             'Single' or 'Batch'(default).
+                             'Single' or 'Batch'.  [default: Batch]
   --tag_to_translate TEXT    HTML elements to translate, separated by commas
+                             [default: p,h1,h2,h3,h4,h5,h6,title]
   --translator_api_url TEXT  stas-server or any other Sugoi Translator
-                             compatible API URL
+                             compatible API URL  [default:
+                             http://localhost:14366]
   -h, --help                 Show this message and exit.
 ```
 

--- a/src/stas_ln_translator/__init__.py
+++ b/src/stas_ln_translator/__init__.py
@@ -20,7 +20,7 @@ def validate_epub_file(ctx, param, value):
 
 
 @click.command(
-    context_settings=dict(help_option_names=["-h", "--help"]),
+    context_settings=dict(help_option_names=["-h", "--help"], show_default=True),
     help="Run stas-ln-translator, an alternative standalone Light Novel translator for Sugoi Translator. Recommended usage with stas-server.",
 )
 @click.version_option(None, "-v", "--version", message="%(version)s")
@@ -28,13 +28,13 @@ def validate_epub_file(ctx, param, value):
     "--batch_size",
     required=False,
     default=100,
-    help="Number of lines per batch in a request. Only works when request_type is 'Batch'.",
+    help="Number of lines per batch in a request. Batch request type only.",
 )
 @click.option(
     "--request_type",
     required=False,
     default="Batch",
-    help="Request type used when contacting API. Either 'Single' or 'Batch'(default).",
+    help="Request type used when contacting API. Either 'Single' or 'Batch'.",
 )
 @click.option(
     "--tag_to_translate",

--- a/src/stas_ln_translator/process.py
+++ b/src/stas_ln_translator/process.py
@@ -17,6 +17,7 @@ def get_all_documents_in_epub(book: epub.EpubBook) -> dict[str, BeautifulSoup]:
     return {
         item.id: BeautifulSoup(item.content, "lxml")
         for item in book.get_items_of_type(ITEM_DOCUMENT)
+        if item.is_chapter()
     }
 
 

--- a/src/stas_ln_translator/process.py
+++ b/src/stas_ln_translator/process.py
@@ -30,7 +30,11 @@ def write_all_documents_to_epub_item(
         documents (dict[str, BeautifulSoup]): Dictionary with document IDs as keys and BeautifulSoup objects as values.
     """
     for item in book.get_items_of_type(ITEM_DOCUMENT):
-        item.content = str(documents[item.id].prettify())
+        currentSoup = documents[item.id]
+        item.content = str(currentSoup.prettify())
+        # Only body will preserved by EBookLib, so we need to manually add title tag back.
+        if currentSoup.title is not None and currentSoup.title.string is not None:
+            item.title = currentSoup.title.string
 
 
 def preprocess_document(soup: BeautifulSoup) -> BeautifulSoup:

--- a/uv.lock
+++ b/uv.lock
@@ -189,7 +189,7 @@ wheels = [
 
 [[package]]
 name = "stas-ln-translator"
-version = "0.1.0"
+version = "1.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "asyncclick" },


### PR DESCRIPTION
Also, include fixes, process only chapter HTML (not cover HTML or navigation HTML), and manually add the title tag if available.